### PR TITLE
chore: scaffold AIDD repository structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-epic.md
+++ b/.github/ISSUE_TEMPLATE/feature-epic.md
@@ -1,0 +1,32 @@
+---
+name: "Feature Epic"
+description: "Production-ready feature composed of multiple Stories."
+title: "[Epic] <Feature name>"
+labels: ["type: epic"]
+assignees: []
+---
+
+## Summary
+One or two sentences describing the feature.
+
+## Architecture Overview (C4/ADRs)
+- C4 Context: <link>
+- C4 Container: <link>
+- C4 Component: <link>
+- ADRs: ADR-001, ADR-002
+
+## Objectives
+- Business goal(s)
+- Technical goal(s)
+- SLOs/SLAs (latency, availability, cost, safety)
+- Risk considerations
+
+## Stories
+- [ ] Story placeholder (link to story issue)
+
+## Definition of Done (DoD)
+- [ ] All Stories complete and merged behind feature flag
+- [ ] Tests pass at all levels (unit, integration, contract, AI eval if relevant)
+- [ ] SLOs validated in CI/perf tests
+- [ ] Docs, runbooks, and monitoring updated
+- [ ] Rollback/feature flag in place

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,46 @@
+---
+name: "Story"
+description: "PR-sized slice of functionality that delivers user value."
+title: "[Story] <Outcome-oriented title>"
+labels: ["type: story"]
+assignees: []
+---
+
+## Summary
+Brief description of the user or system behavior.
+
+## Acceptance Criteria
+- [ ] Given/When/Then #1
+- [ ] Given/When/Then #2
+
+## Contracts & Compatibility
+- Contract delta(s): <OpenAPI/GraphQL/Protobuf path and version>
+- Versioning & deprecation plan: <strategy>
+
+## Test Strategy
+- Unit tests: <scope>
+- Property tests (if applicable): <scope>
+- Contract tests: <scope>
+- Integration slice tests: <scope>
+- AI evals (if applicable): <scope>
+
+## Observability
+- Metrics: name, labels, cardinality budget
+- Logs: event names, structure, retention
+- Traces: spans/instrumentation updates
+
+## Tasks
+- [ ] Task placeholder (link to task issue)
+
+## Definition of Ready (DoR)
+- [ ] Acceptance criteria defined
+- [ ] Contracts drafted and reviewed
+- [ ] Test strategy approved
+- [ ] Observability plan documented
+
+## Definition of Done (DoD)
+- [ ] All tasks complete and traceable
+- [ ] Tests added/updated and passing
+- [ ] Observability assets deployed
+- [ ] Docs/runbooks updated
+- [ ] Feature flag in place with rollback plan

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,33 @@
+---
+name: "Task"
+description: "Per-prompt unit of work or small developer action supporting a Story."
+title: "[Task] <Actionable verb + object>"
+labels: ["type: task"]
+assignees: []
+---
+
+## Story Link
+Parent Story: #<StoryID>
+
+## Objective
+What this Task achieves toward the Story.
+
+## Steps (as applicable)
+- [ ] Update/define contracts (OpenAPI/Proto/GraphQL SDL)
+- [ ] Write acceptance tests (ATDD/BDD) and unit/property tests
+- [ ] Implement code changes against tests
+- [ ] Add/adjust metrics, logs, traces
+- [ ] Update documentation/runbook
+
+## Outputs
+- PR: #<PR-ID>
+- File(s): <path>
+- Tests: <path to test suites>
+
+## Traceability
+Map to Story acceptance criteria and ADRs touched.
+
+## Definition of Done (Task)
+- [ ] Tests written and passing locally/CI
+- [ ] Changes linked to Story; references ADRs if applicable
+- [ ] Code reviewed/approved or attached to PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+<!-- High-level description of the change. What problem does it solve? -->
+
+## Related Work
+- **Feature Epic(s):** #EPIC-ID
+- **Story(ies):** #STORY-ID
+- **Task(s):** #TASK-ID
+- **ADR(s):** [ADR-###](./docs/adr/ADR-###-title.md)
+
+## Architecture Impact
+- [ ] No architectural changes
+- [ ] Yes, ADR(s) linked above
+
+If "Yes," summarize:
+- **Contracts/Interfaces Changed:** <details>
+- **Persistence/Infra Changes:** <details>
+- **New Dependencies:** <details>
+
+## Tests & Quality Gates
+- [ ] Unit tests added/updated
+- [ ] Property/contract tests added/updated
+- [ ] Integration tests added/updated
+- [ ] AI evals run (if applicable)
+- [ ] Coverage ≥ target
+- [ ] Mutation score ≥ target
+
+## Observability & Ops
+- [ ] Metrics/logs/traces updated
+- [ ] Alerts/dashboards updated
+- [ ] Runbooks updated
+
+## Checklist
+- [ ] Code follows style guidelines
+- [ ] Docs updated (README, ADRs, etc.)
+- [ ] Feature behind a flag
+- [ ] Rollback plan documented

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Agent Guidance
+
+## Scope
+These instructions apply to the entire repository unless a more specific `AGENTS.md` overrides them in a subdirectory.
+
+## Contribution Guidelines
+- Follow the AI-Driven Development (AIDD) workflow: keep Epics, Stories, Tasks, and ADRs in sync using the provided templates.
+- When adding new artifacts, place them in the appropriate directory:
+  - `docs/adr/` for ADRs (use `ADR-TEMPLATE.md` as the starting point).
+  - `.github/ISSUE_TEMPLATE/` for issue templates.
+  - `prompts/` for reusable prompts (version them semantically).
+  - `contracts/` for source-of-truth interface definitions.
+  - `infrastructure/` for infrastructure-as-code assets.
+- Maintain traceability between Epics → Stories → Tasks → ADRs by referencing IDs in front-matter or checklists.
+
+## Markdown Style
+- Use sentence case for headings and keep line length under 120 characters where practical.
+- Prefer unordered lists for checklists and ordered lists only when sequence matters.
+- Surround placeholders with angle brackets (e.g., `<placeholder>`).
+
+## Testing
+- This repository currently has no automated test suites. If you add executable code, include appropriate tests and document how to run them.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts
+
+Store authoritative API/interface contracts here.
+
+- Support OpenAPI, GraphQL SDL, Protobuf, or JSON Schema files.
+- Version contracts explicitly and document deprecation timelines.
+- Reference contract updates from Stories, Tasks, and ADRs.

--- a/docs/adr/ADR-TEMPLATE.md
+++ b/docs/adr/ADR-TEMPLATE.md
@@ -1,0 +1,34 @@
+# Architecture Decision Record (ADR)
+
+## Title
+<Short, descriptive title>
+
+## Status
+Proposed | Accepted | Deprecated | Superseded by ADR-XXX
+
+> Include date and decision owner; keep ADRs immutable after “Accepted” (create a new ADR to change course).
+
+## Context
+- What problem are we solving?
+- What constraints or forces shape the decision?
+- Background, related epics/stories/incidents.
+
+## Decision
+- The decision we made.
+- Include diagrams, snippets, or contracts if relevant.
+
+> If contracts change, link exact versions (e.g., OpenAPI commit hash) and deprecation policy. Note any backward/forward compatibility guarantees.
+
+## Rationale
+- Why this decision?
+- Alternatives considered and why not chosen.
+- Tradeoffs or risks accepted.
+
+## Consequences
+- Positive outcomes (enablers, simplifications).
+- Negative outcomes (risks, complexity, migration costs).
+- Future considerations (when to revisit?).
+
+## References
+- Links to related ADRs, epics, stories, contracts.
+- External references (RFCs, docs, benchmarks).

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,7 @@
+# Infrastructure
+
+Track infrastructure-as-code assets (Terraform, Pulumi, Helm, Kubernetes manifests, etc.).
+
+- Group resources by environment or service as needed.
+- Document provisioning steps and shared variables.
+- Link infrastructure changes to relevant Stories, Tasks, and ADRs.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,7 @@
+# Prompt Registry
+
+Use this directory to store reusable prompts and tool instructions.
+
+- Organize prompts by domain (e.g., `auth/1.0.0.md`).
+- Include context, inputs, and expected outputs for each prompt.
+- Track semantic versions to manage prompt evolution and governance.


### PR DESCRIPTION
## Summary
- scaffold core directories for ADRs, prompts, contracts, and infrastructure assets
- add issue and pull request templates aligned with the AIDD workflow
- document repository-wide agent guidance for future contributors

## Testing
- not run (documentation and templates only)


------
https://chatgpt.com/codex/tasks/task_e_68cd8870dd508323bb04698371866c88