### PR TITLE
Add Bootstrap prompts documentation and backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * [GATES.md](./GATES.md)
 * [Templates](#templates)
   * [TEMPLATES.md](./TEMPLATES.md)
+* [Bootstrap](#bootstrap)
 
 ---
 
@@ -187,7 +188,62 @@ See [GATES.md](./GATES.md).
 See [TEMPLATES.md](./TEMPLATES.md).
 
 Suggested templates:
-* **Feature Epic Template** → Architecture overview, ADR links, objectives, incremental plan.  
-* **Story Template** → Acceptance criteria, contract deltas, test plan, DoR/DoD.  
-* **Task Template** → Prompt/tooling steps, linked Story/ADR, test-first checklist.  
-* **ADR Template** → Context, decision, rationale, alternatives.  
+* **Feature Epic Template** → Architecture overview, ADR links, objectives, incremental plan.
+* **Story Template** → Acceptance criteria, contract deltas, test plan, DoR/DoD.
+* **Task Template** → Prompt/tooling steps, linked Story/ADR, test-first checklist.
+* **ADR Template** → Context, decision, rationale, alternatives.
+
+## Bootstrap
+
+# BOOTSTRAP PROMPT: Fresh Project
+
+
+Review the following four web resources:
+
+- https://github.com/crashtestbrandt/AIDD/blob/main/README.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/TEMPLATES.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/GATES.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/PROMPTS.md  
+
+Then:  
+
+This repository needs to follow the AIDD ("AI-Driven Development & Delivery") framework. Generate a detailed plan / checklist / scaffold (in Markdown) for how to structure the repository, what configuration files, templates, gates, and prompt assets to include, how to integrate them, and what workflows to establish.  
+
+Include in your plan:
+
+- folder & file layout for code, templates, prompts, gates, etc.  
+- what initial template files to include (and rough content or placeholders) using AIDD’s template style  
+- what "gates" (quality / review checkpoints) to set up, and how to enforce them (e.g. via CI, pull request reviews, tooling)  
+- what prompts to capture or define upfront, per AIDD’s PROMPTS.md guidelines  
+- how to ensure the project remains consistent with the AIDD philosophy over time (e.g. versioning of templates, ownership, onboarding)  
+- approximate timeline / phases for getting all this in place  
+
+Output should be actionable, defensible (you can explain *why* each component is useful), and tailored for a fresh project starting from scratch.  
+
+---
+
+# BOOTSTRAP PROMPT: Existing Project
+
+Review the following four web resources:
+
+- https://github.com/crashtestbrandt/AIDD/blob/main/README.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/TEMPLATES.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/GATES.md  
+- https://github.com/crashtestbrandt/AIDD/blob/main/PROMPTS.md  
+
+Then:  
+
+
+Your goal is to adapt this project to comply with the AIDD ("AI-Driven Development") framework. Produce a detailed, incremental implementation plan (with phases) that is defensible, practical, and minimizes disruption.  
+
+The plan should include:
+
+- a baseline assessment: what parts of the current project already align with AIDD (templates, prompt assets, quality gates, etc.), and what is missing  
+- phase-by-phase steps (e.g. Phase 1: quick wins; Phase 2: deeper integration; Phase 3: process embedding).  
+- for each phase, which templates to introduce or update, which existing artifacts to refactor, which gates to enforce and how (CI, PR policy, tooling, etc.)  
+- how to define / capture missing prompts (per PROMPTS.md) and where to store them  
+- how to integrate the gates (from GATES.md) in the existing workflow without large disruption  
+- how to manage change: version control, documentation, ownership, training of team, rollback / risk mitigation  
+- metrics or checkpoints to evaluate progress and ensure adoption  
+
+Produce the plan in a format suitable for presentation (e.g. as a roadmap or schedule) so stakeholders can see what will be done, when, and why.

--- a/docs/backlog/feature-epics/bootstrap-tooling.md
+++ b/docs/backlog/feature-epics/bootstrap-tooling.md
@@ -1,0 +1,33 @@
+---
+id: EPIC-BT-001
+title: Bootstrap tooling
+status: proposed
+story_ids:
+  - STORY-BT-001
+---
+
+**Title:** Bootstrap tooling
+**Summary:** Establish bootstrap assets that seed new or existing projects with AIDD prompts and guidance.
+
+## Architecture Overview
+
+* C4 Model links: Not applicable for documentation-focused bootstrap assets.
+* ADR references: None yet; bootstrap documentation does not introduce architectural changes.
+* Architecture conformance notes: Aligns with the baseline AIDD repository structure defined in the root documentation.
+
+## Objectives
+
+* Provide canonical bootstrap prompts for greenfield and brownfield adoption.
+* Enable consistent kickoff workflows for teams adopting AIDD.
+* Reduce ramp-up time by centralizing guidance for AI + human collaborators.
+
+## Stories
+
+* [ ] [STORY-BT-001](../stories/bootstrap-prompts.md) — Bootstrap prompts
+
+## Definition of Done (DoD)
+
+* All Stories complete and merged with review approval.
+* Documentation and supporting assets published with clear traceability to the Epic.
+* Any supporting templates or prompts versioned and discoverable from the repo root.
+* Rollback or archival plan documented for deprecated bootstrap assets.

--- a/docs/backlog/stories/bootstrap-prompts.md
+++ b/docs/backlog/stories/bootstrap-prompts.md
@@ -1,0 +1,47 @@
+---
+id: STORY-BT-001
+status: planned
+epic: EPIC-BT-001
+task_ids:
+  - TASK-BT-001
+---
+
+**Title:** Bootstrap prompts
+**Epic Link:** [EPIC-BT-001](../feature-epics/bootstrap-tooling.md)
+**Summary:** Capture AIDD bootstrap prompts inside the README to guide new and existing projects.
+
+## Scope
+
+* In scope: Documenting bootstrap prompts in the README; ensuring wording remains verbatim per requirements.
+* Out of scope: Authoring new templates, modifying existing gates, or altering repository automation.
+
+## Acceptance Criteria
+
+* The README includes a "Bootstrap" section with subsections for fresh and existing projects.
+* Each subsection embeds the provided prompt text verbatim, including formatting and bullet structure.
+* The Story is traceable back to the Feature Epic and associated Task.
+
+## Contracts
+
+* Not applicable. No API or interface contracts change for documentation updates.
+
+## Test Strategy
+
+* Peer review for formatting accuracy and adherence to verbatim prompt text.
+* Markdown linting or preview (manual) to verify headings render correctly.
+* Ensure repository guidance links remain valid.
+
+## Observability
+
+* Not applicable. No runtime telemetry changes are introduced.
+
+## Tasks
+
+* [ ] [TASK-BT-001](../tasks/add-bootstrap-prompts-to-readme.md) — Add Bootstrap prompts to README
+
+## Definition of Done
+
+* Acceptance criteria validated via review of the rendered README.
+* Documentation updates merged with all required checks passing.
+* Traceability confirmed between Epic, Story, and Task metadata.
+* Stakeholders notified that bootstrap prompts are available in canonical documentation.

--- a/docs/backlog/tasks/add-bootstrap-prompts-to-readme.md
+++ b/docs/backlog/tasks/add-bootstrap-prompts-to-readme.md
@@ -1,0 +1,35 @@
+---
+id: TASK-BT-001
+status: planned
+story: STORY-BT-001
+---
+
+**Title:** Add Bootstrap prompts to README
+**Story Link:** [STORY-BT-001](../stories/bootstrap-prompts.md)
+**Summary:** Insert the required Bootstrap prompts into the README with correct formatting and traceability references.
+
+## Objective
+
+* Ensure the canonical README contains AIDD-aligned bootstrap prompts for fresh and existing projects.
+
+## Steps
+
+* Update the README with a new "Bootstrap" section that houses the provided prompt text.
+* Verify prompt content remains verbatim, including headings, spacing, and bullet formatting.
+* Cross-check links to AIDD resources for accuracy.
+
+## Outputs
+
+* README section documenting Bootstrap prompts for fresh and existing projects.
+* Commit message referencing TASK-BT-001 and STORY-BT-001 for traceability.
+
+## Traceability
+
+* Supports Story acceptance criterion: README exposes Bootstrap prompts for both project states.
+* Inherits architectural context from Feature Epic EPIC-BT-001.
+
+## Definition of Done
+
+* README renders the new section correctly and matches the provided prompt text exactly.
+* Changes reviewed and merged with repository checks passing.
+* Traceability maintained between Task, Story, and Feature Epic metadata.


### PR DESCRIPTION
This pull request introduces structured documentation and canonical prompts to support AIDD (AI-Driven Development & Delivery) bootstrap workflows for both new and existing projects. It adds a new "Bootstrap" section with actionable prompts to the `README.md` and establishes clear traceability from epic to task in the documentation backlog. The changes are organized to ensure teams can quickly adopt or migrate to AIDD practices with minimal friction.

**Documentation updates for AIDD bootstrap:**

* Added a "Bootstrap" section to `README.md` containing detailed prompts for initializing either fresh or existing projects in alignment with the AIDD framework. This includes explicit instructions, resource links, and actionable checklists for both scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R249)

**Backlog and traceability enhancements:**

* Created a new feature epic `docs/backlog/feature-epics/bootstrap-tooling.md` outlining the objectives, architecture context, and definition of done for bootstrap tooling documentation.
* Added a story `docs/backlog/stories/bootstrap-prompts.md` describing the requirements, acceptance criteria, and test strategy for embedding bootstrap prompts in the README.
* Introduced a task `docs/backlog/tasks/add-bootstrap-prompts-to-readme.md` with step-by-step instructions and traceability to ensure the README update is performed accurately and is linked to the corresponding story and epic.## Summary
- add a Bootstrap section to the README containing the supplied prompts for fresh and existing projects
- introduce backlog records for the Bootstrap tooling feature epic, Bootstrap prompts story, and README update task to maintain traceability

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd9c2920508323b0f4e31242861c98