### PR TITLE
Add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+
+## Copilot Instructions (Delegated)
+
+All authoritative agent, architecture, workflow, and coding conventions are consolidated in `AGENTS.md`.
+
+Agents: Do not rely on (or expand) this file. Always open and follow `AGENTS.md` for up-to-date guidance. If instructions need revision, edit `AGENTS.md` only and keep this redirect file unchanged.
+
+Nothing else belongs here.


### PR DESCRIPTION
## Summary

This pull request introduces a new documentation file to clarify the source of authoritative guidance for Copilot instructions. The new file directs users to consult `AGENTS.md` for all up-to-date conventions and instructions.

Documentation update:

* Added `.github/copilot-instructions.md` as a redirect, instructing agents to reference `AGENTS.md` for all authoritative agent, architecture, workflow, and coding conventions, and not to modify this file.

## Related Work
- **Feature Epic(s):** #EPIC-ID
- **Story(ies):** #STORY-ID
- **Task(s):** #TASK-ID
- **ADR(s):** [ADR-###](./docs/adr/ADR-###-title.md)

## Architecture Impact
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:** <details>
- **Persistence/Infra Changes:** <details>
- **New Dependencies:** <details>

## Tests & Quality Gates
- [ ] Unit tests added/updated
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [ ] Coverage ≥ target
- [ ] Mutation score ≥ target

## Observability & Ops
- [ ] Metrics/logs/traces updated
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [ ] Code follows style guidelines
- [x] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag
- [ ] Rollback plan documented
