### PR TITLE
Update hooks settings to nested array format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,13 +3,23 @@
     "PostToolUse": [
       {
         "matcher": "Bash",
-        "command": "scripts/hooks/check-commit-refs.sh",
-        "description": "Warn if commit message lacks Story/Task reference"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/hooks/check-commit-refs.sh",
+            "description": "Warn if commit message lacks Story/Task reference"
+          }
+        ]
       },
       {
         "matcher": "Bash",
-        "command": "scripts/hooks/check-adr-required.sh",
-        "description": "Warn if architectural files staged without ADR reference"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/hooks/check-adr-required.sh",
+            "description": "Warn if architectural files staged without ADR reference"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Migrates PostToolUse hook configuration in `.claude/settings.json` from flat `command`/`description` fields to the nested `hooks` array structure with explicit `type` field
- Aligns settings format with current Claude Code hooks schema

## Related Work
- TASK-1

## Architecture Impact
No architectural impact. Configuration-only change updating hook definition format.

## Tests & Quality Gates
- [x] Settings JSON is valid
- [x] Hook commands and descriptions preserved

## Observability & Ops
N/A — no runtime changes.

## Rollback Plan
Revert commit to restore previous flat hook format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)